### PR TITLE
Add supports for file in gradle task

### DIFF
--- a/src/main/groovy/com/xmlcalabash/XMLCalabashExec.groovy
+++ b/src/main/groovy/com/xmlcalabash/XMLCalabashExec.groovy
@@ -147,8 +147,16 @@ class XMLCalabashExec extends JavaExec {
         return this
     }
 
+    String input(String port, File file) {
+        input(port, file.absolutePath)
+    }
+
     String input(String port, String filename) {
         inputs.add("-i" + port + "=" + filename)
+    }
+
+    String dataInput(String port, File file) {
+        dataInput(port, file.absolutePath)
     }
 
     String dataInput(String port, String filename) {
@@ -161,6 +169,10 @@ class XMLCalabashExec extends JavaExec {
         } else {
             inputs.add("-d" + port + "=" + contentType + "@" + filename)
         }
+    }
+
+    String output(String port, File file) {
+        output(port, file.absolutePath)
     }
 
     String output(String port, String filename) {

--- a/src/main/groovy/com/xmlcalabash/XMLCalabashTask.groovy
+++ b/src/main/groovy/com/xmlcalabash/XMLCalabashTask.groovy
@@ -148,8 +148,16 @@ class XMLCalabashTask extends ConventionTask {
         return this
     }
 
+    String input(String port, File file) {
+        input(port, file.absolutePath)
+    }
+
     String input(String port, String filename) {
         inputs.add("-i" + port + "=" + filename)
+    }
+
+    String dataInput(String port, File file) {
+        dataInput(port, file.absolutePath)
     }
 
     String dataInput(String port, String filename) {
@@ -162,6 +170,10 @@ class XMLCalabashTask extends ConventionTask {
         } else {
             inputs.add("-d" + port + "=" + contentType + "@" + filename)
         }
+    }
+
+    String output(String port, File file) {
+        output(port, file.absolutePath)
     }
 
     String output(String port, String filename) {

--- a/src/test/groovy/com/xmlcalabash/XMLCalabashExecTest.groovy
+++ b/src/test/groovy/com/xmlcalabash/XMLCalabashExecTest.groovy
@@ -2,6 +2,7 @@ package com.xmlcalabash
 
 import com.xmlcalabash.XMLCalabashExec
 
+import java.io.File;
 import org.junit.Test
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.api.Project
@@ -13,5 +14,17 @@ class XMLCalabashExecTest {
         Project project = ProjectBuilder.builder().build()
         def task = project.task('calabash', type: XMLCalabashExec)
         assertTrue(task instanceof XMLCalabashExec)
+    }
+
+    @Test
+    public void canUseFile() {
+        Project project = ProjectBuilder.builder().build()
+        def task = project.task('calabash', type: XMLCalabashExec)
+        task.pipeline = new File("pipe.xpl")
+        task.input("source", new File("source.xml"))
+        task.output("result", new File("result.xml"))
+        def args = task.getArgs()
+        assertTrue(String.join(" ", args), args.contains("-isource=" + new File("source.xml").absolutePath))
+        assertTrue(String.join(" ", args), args.contains("-oresult=" + new File("result.xml").absolutePath))
     }
 }

--- a/src/test/groovy/com/xmlcalabash/XMLCalabashTaskTest.groovy
+++ b/src/test/groovy/com/xmlcalabash/XMLCalabashTaskTest.groovy
@@ -2,6 +2,7 @@ package com.xmlcalabash
 
 import com.xmlcalabash.XMLCalabashTask
 
+import java.io.File
 import org.junit.Test
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.api.Project
@@ -14,4 +15,17 @@ class XMLCalabashTaskTest {
         def task = project.task('calabash', type: XMLCalabashTask)
         assertTrue(task instanceof XMLCalabashTask)
     }
+
+    @Test
+    public void canUseFile() {
+        Project project = ProjectBuilder.builder().build()
+        def task = project.task('calabash', type: XMLCalabashTask)
+        task.pipeline = new File("pipe.xpl")
+        task.input("source", new File("source.xml"))
+        task.output("result", new File("result.xml"))
+        def args = task.getArgs()
+        assertTrue(String.join(" ", args), args.contains("-isource=" + new File("source.xml").absolutePath))
+        assertTrue(String.join(" ", args), args.contains("-oresult=" + new File("result.xml").absolutePath))
+    }
+
 }


### PR DESCRIPTION
My issue is that when running the tasks from Eclipse, the path is
relative to the gradle executable instead of the current directory.
Passing a File instead of a String helps but the XMLCalabash supports
only strings.

``` gradle
defaultTasks 'run'

task run(type: com.xmlcalabash.XMLCalabashTask) {
  pipeline = file("pipe.xpl")
  debugPipeline = true
  safeMode = true

  input('source', file('src/document.xml').absolutePath)
  input('schema', file('src/document.rng').absolutePath)

  input('html.xsl', file('xsl/html.xsl').absolutePath)
  input('svg.xsl', file('xsl/svg.xsl').absolutePath)
  input('xslfo.xsl', file('xsl/xslfo.xsl').absolutePath)

  output('html', file('output/document.html').absolutePath)
  option('pdf', file('output/document.pdf').toURI().toString())
  output('fo', file('output/document.fo').absolutePath)
  output('svg', file('output/document.svg').absolutePath)
}
run.group = "application"
run.description = "run the pipeline"
```
