### PR TITLE
Don't require sonatype properties to parse build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+.idea
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-import groovy.swing.SwingBuilder
-import java.awt.Point
-
 plugins {
   id "groovy"
   id "osgi"
@@ -127,6 +124,11 @@ uploadArchives {
 signing {
   required { gradle.taskGraph.hasTask("uploadArchives") }
   sign configurations.archives
+}
+
+if(!(ext.has('sonatypeUsername') && ext.has('sonatypePassword'))) {
+  ext.sonatypeUsername = ''
+  ext.sonatypePassword = ''
 }
 
 uploadArchives {


### PR DESCRIPTION
build.gradle could not be interpreted unless `sonatypeUsername` and
`sonatypePassword` were present as properties in the project. If either
are missing, just default to empty strings. `uploadArchives` will of
course fail in such a case, but at least the rest of the script is usable.